### PR TITLE
feat: show progress spinner during LLM calls (#61)

### DIFF
--- a/agent_bmm/coder/engine.py
+++ b/agent_bmm/coder/engine.py
@@ -24,6 +24,7 @@ from pathlib import Path
 
 from rich.console import Console
 from rich.panel import Panel
+from rich.status import Status
 
 from agent_bmm.coder.context import ContextManager
 from agent_bmm.coder.permissions import PermissionLevel, PermissionManager
@@ -470,15 +471,35 @@ class CoderAgent:
 
         try:
             if self.stream:
-                # Stream tokens to terminal
-                console.print("  [dim]", end="")
+                # Show spinner during initial connection, then stream tokens
+                spinner = Status("  [yellow]Thinking...[/]", console=console, spinner="dots")
+                spinner.start()
+                first_token = True
+
+                def on_token(t: str):
+                    nonlocal first_token
+                    if first_token:
+                        spinner.stop()
+                        console.print("  [dim]", end="")
+                        first_token = False
+                    console.print(t, end="", highlight=False)
+
                 response = await self.llm.chat_stream(
                     self.history,
-                    on_token=lambda t: console.print(t, end="", highlight=False),
+                    on_token=on_token,
                 )
-                console.print("[/]")
+                if first_token:
+                    spinner.stop()
+                else:
+                    console.print("[/]")
             else:
-                response = await self.llm.chat(self.history)
+                # Non-streaming: show spinner for entire LLM call
+                spinner = Status("  [yellow]Thinking...[/]", console=console, spinner="dots")
+                spinner.start()
+                try:
+                    response = await self.llm.chat(self.history)
+                finally:
+                    spinner.stop()
         except Exception as e:
             self.history.append({"role": "user", "content": f"LLM Error: {e}. Try again."})
             return None

--- a/agent_bmm/core/chain.py
+++ b/agent_bmm/core/chain.py
@@ -17,6 +17,8 @@ import asyncio
 from dataclasses import dataclass
 
 import torch
+from rich.console import Console
+from rich.status import Status
 
 from agent_bmm.core.router import BMMRouter
 from agent_bmm.llm.backend import LLMBackend
@@ -96,7 +98,13 @@ class AgentChain:
         messages = self.memory.to_messages()
         system = self._build_system_prompt()
         messages.insert(0, {"role": "system", "content": system})
-        return await self.llm.chat(messages)
+        _console = Console()
+        spinner = Status("  [yellow]Thinking...[/]", console=_console, spinner="dots")
+        spinner.start()
+        try:
+            return await self.llm.chat(messages)
+        finally:
+            spinner.stop()
 
     def _route(self, thought: str) -> list[int]:
         """BMM routing — select tools based on LLM thought."""

--- a/agent_bmm/core/logging.py
+++ b/agent_bmm/core/logging.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass, field
 
 from rich.console import Console
 from rich.panel import Panel
+from rich.status import Status
 from rich.table import Table
 
 console = Console()
@@ -48,6 +49,7 @@ class AgentLogger:
         self.entries: list[BMMTraceEntry] = []
         self._step = 0
         self._start_time = 0.0
+        self._spinner: Status | None = None
 
     def start(self, query: str):
         """Log agent start."""
@@ -141,6 +143,18 @@ class AgentLogger:
                     border_style="green",
                 )
             )
+
+    def log_llm_start(self, message: str = "Thinking..."):
+        """Start a spinner while waiting for LLM response."""
+        if self.verbose:
+            self._spinner = Status(f"  [yellow]{message}[/]", console=console, spinner="dots")
+            self._spinner.start()
+
+    def log_llm_done(self):
+        """Stop the LLM spinner."""
+        if self._spinner is not None:
+            self._spinner.stop()
+            self._spinner = None
 
     def log_error(self, error: str):
         """Log an error."""


### PR DESCRIPTION
Add Rich spinner animation while waiting for LLM responses:
- AgentLogger: log_llm_start()/log_llm_done() for spinner lifecycle
- CoderAgent: spinner during non-streaming calls and initial connection
- AgentChain: spinner during _think() LLM reasoning step